### PR TITLE
Add conversions for Bushels

### DIFF
--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -397,6 +397,14 @@ const unitLookupList = [
       /sq.? kilometers?/,
       /km[^]2/
     ]
+  },
+  {
+    "imperialUnits" : [/bushels?/],
+    "standardInputUnit" : " bushels",
+    "isInvalidInput" : isZeroOrNegative,
+    "isWeaklyInvalidInput" : isHyperbole,
+    "conversionFunction" : (i) => weightMap(i * 35239.07040000007),
+    "ignoredUnits" : metricWeightUnits
   }
 ];
 

--- a/test/converter-test.js
+++ b/test/converter-test.js
@@ -335,6 +335,21 @@ describe('Converter', () => {
       });
     });
 
+    context('bushels', () => {
+      it('should convert', () => {
+        testConvert(
+          [
+            "1 bushel",
+            "2 bushels"
+          ],
+          {
+            "1 bushels" : "35 kg",
+            "2 bushels" : "70 kg"
+          }
+        );
+      }) 
+    })
+
     context('supported special characters', () => {
       it('should convert when starting with special characters', () => {
         testConvert(


### PR DESCRIPTION
Closes Issue #32 Bushels to kg.
Added Bushels to Grams conversions in src/conversion_helper.js
Wrote basic test for Bushel conversions in test/converter-test.js
Note: A bushel is most frequently used as a measurement was weight, but
was historically a measurement of volume.  In certain situations, a
bushel's weight is determined by the contents being measured, e.g. oats,
apples, husked corn of a certain moisture percetange, etc.  Even these
definitions vary by local.  Due to this, the common measurement of a
bushel equalling about 35.239 kg is used.

