### PR TITLE
Add support for fractions

### DIFF
--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -529,15 +529,20 @@ function shouldConvertComment(comment, regexArray = globalIgnore, shouldBeUnique
 */
 function preprocessComment(comment) {
   function fractionProcessor(input) {
-    var mixedRegex = new RegExp((rh.numberRegex + /(?:\s+)/.source + rh.numberRegex + "/" + rh.numberRegex), 'gi');
-    var fractionRegex = new RegExp(rh.numberRegex + "/" + rh.numberRegex, 'gi');
+    var mixedRegex = new RegExp((rh.numberRegex + /(?:[\s+-]+)/.source + rh.numberRegex + "/" + rh.numberRegex + /([\s-])/.source), 'gi');
+    var fractionRegex = new RegExp(rh.numberRegex + "/" + rh.numberRegex + /([\s-])/.source, 'gi');
 
-    input = input.replace(mixedRegex, function(p1, p2, p3, p4) {
-        return p2.toString() + (p3/p4).toFixed(2).substr(1);
+    input = input.replace(mixedRegex, function(p1, p2, p3, p4, p5) {
+        p2 = p2.replace(/,+/g, '');
+        p3 = p3.replace(/,+/g, '');
+        p4 = p4.replace(/,+/g, '');
+        return (parseInt(p2)+parseInt(p3)/parseInt(p4)).toFixed(2) + p5;
     });
 
-    input = input.replace(fractionRegex, function(p1, p2, p3, p4) {
-        return (p2/p3).toFixed(2);
+    input = input.replace(fractionRegex, function(p1, p2, p3, p4, p5) {
+        p2 = p2.replace(/,+/g, '');
+        p3 = p3.replace(/,+/g, '');
+        return (p2/p3).toFixed(2) + p4;
     });
 
     return input;

--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -522,22 +522,22 @@ function shouldConvertComment(comment, regexArray = globalIgnore, shouldBeUnique
 }
 
 /*
-  Input: String
+  Input: Comment
     "1 3/4 miles"
-  Output: String processed to fix user formatting
+  Output: Comment with body processed to fix user formatting
     "1.75 miles"
 */
 function preprocessComment(comment) {
   function fractionProcessor(input) {
-    var mixedRegex = new RegExp((rh.numberRegex + /(?:\s*)/.source + rh.numberRegex + "/" + rh.numberRegex), 'gi');
+    var mixedRegex = new RegExp((rh.numberRegex + /(?:\s+)/.source + rh.numberRegex + "/" + rh.numberRegex), 'gi');
     var fractionRegex = new RegExp(rh.numberRegex + "/" + rh.numberRegex, 'gi');
 
-    input = input.replace(mixedRegex, function(match) {
-        return match[0].toString() + (match[2]/match[4]).toFixed(2).substr(1);
+    input = input.replace(mixedRegex, function(p1, p2, p3, p4) {
+        return p2.toString() + (p3/p4).toFixed(2).substr(1);
     });
 
-    input = input.replace(fractionRegex, function(match) {
-        return (match[0]/match[2]).toFixed(2);
+    input = input.replace(fractionRegex, function(p1, p2, p3, p4) {
+        return (p2/p3).toFixed(2);
     });
 
     return input;

--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -523,6 +523,32 @@ function shouldConvertComment(comment, regexArray = globalIgnore, shouldBeUnique
 
 /*
   Input: String
+    "1 3/4 miles"
+  Output: String processed to fix user formatting
+    "1.75 miles"
+*/
+function preprocessComment(comment) {
+  function fractionProcessor(input) {
+    var mixedRegex = new RegExp((rh.numberRegex + /(?:\s*)/.source + rh.numberRegex + "/" + rh.numberRegex), 'gi');
+    var fractionRegex = new RegExp(rh.numberRegex + "/" + rh.numberRegex, 'gi');
+
+    input = input.replace(mixedRegex, function(match) {
+        return match[0].toString() + (match[2]/match[4]).toFixed(2).substr(1);
+    });
+
+    input = input.replace(fractionRegex, function(match) {
+        return (match[0]/match[2]).toFixed(2);
+    });
+
+    return input;
+  }
+
+  comment['body'] = fractionProcessor(comment['body']);
+  return comment;
+}
+
+/*
+  Input: String
     "1-2 mi away at 3 miles an hour"
   Output: Array of input numbers and standardized units
     [
@@ -886,6 +912,7 @@ function formatConversion(conversions) {
 module.exports = {
   globalIgnore,
   "shouldConvertComment" : shouldConvertComment,
+  "preprocessComment": preprocessComment,
   "findPotentialConversions" : findPotentialConversions,
   "filterConversions" : filterConversions,
   "calculateMetric" : calculateMetric,

--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -529,17 +529,20 @@ function shouldConvertComment(comment, regexArray = globalIgnore, shouldBeUnique
 */
 function preprocessComment(comment) {
   function fractionProcessor(input) {
-    var mixedRegex = new RegExp((rh.numberRegex + /(?:[\s+-]+)/.source + rh.numberRegex + "/" + rh.numberRegex + /([\s-])/.source), 'gi');
-    var fractionRegex = new RegExp(rh.numberRegex + "/" + rh.numberRegex + /([\s-])/.source, 'gi');
+    const frac = new RegExp(rh.fractionRegex, 'gi');
+    
+    const mixed = new RegExp(rh.numberRegex
+                    + /(?:[\s+-]+)/.source
+                    + rh.fractionRegex, 'gi');
 
-    input = input.replace(mixedRegex, function(p1, p2, p3, p4, p5) {
+    input = input.replace(mixed, function(p1, p2, p3, p4, p5) {
         p2 = p2.replace(/,+/g, '');
         p3 = p3.replace(/,+/g, '');
         p4 = p4.replace(/,+/g, '');
         return (parseInt(p2)+parseInt(p3)/parseInt(p4)).toFixed(2) + p5;
     });
 
-    input = input.replace(fractionRegex, function(p1, p2, p3, p4, p5) {
+    input = input.replace(frac, function(p1, p2, p3, p4) {
         p2 = p2.replace(/,+/g, '');
         p3 = p3.replace(/,+/g, '');
         return (p2/p3).toFixed(2) + p4;

--- a/src/converter.js
+++ b/src/converter.js
@@ -7,7 +7,8 @@ function conversions(comment) {
     return {};
   }
 
-  const potentialConversions = ch.findPotentialConversions(comment);
+  const preprocessedcomment = ch.preprocessComment(comment);
+  const potentialConversions = ch.findPotentialConversions(preprocessedcomment);
   const filteredConversions = ch.filterConversions(potentialConversions);
   const metricConversions = ch.calculateMetric(filteredConversions);
   const roundedConversions = ch.roundConversions(metricConversions);

--- a/src/regex_helper.js
+++ b/src/regex_helper.js
@@ -40,11 +40,18 @@ const rangeRegex
   + / ?(?:-|to) ?/.source
   + numberRegex;
 
+const fractionRegex
+  = numberRegex
+  + "/"
+  + numberRegex
+  + /([\s-])/.source;
+
 module.exports = {
   "regexJoinToString" : regexJoinToString,
   "addCommas" : addCommas,
   startRegex,
   endRegex,
   numberRegex,
-  rangeRegex
+  rangeRegex,
+  fractionRegex
 }

--- a/test/conversion_helper-test.js
+++ b/test/conversion_helper-test.js
@@ -62,8 +62,8 @@ describe('conversion_helper', () => {
     });
     context('comment contains fraction', () => {
         it('should convert fractions into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 9/10 miles");
-          ch.preprocessComment(comment)['body'].should.equal("post text 0.90 miles");
+          const comment = createComment("subredditname", "post title", "post text 9/10-miles");
+          ch.preprocessComment(comment)['body'].should.equal("post text 0.90-miles");
         });
         it('should convert fractions into decimals', () => {
           const comment = createComment("subredditname", "post title", "post text 177/100 miles more text");

--- a/test/conversion_helper-test.js
+++ b/test/conversion_helper-test.js
@@ -41,6 +41,37 @@ describe('conversion_helper', () => {
     });
   });
 
+  describe('#preprocessComment()', () => {
+    context('comment contains mixed', () => {
+        it('should convert mixed values into decimals', () => {
+          const comment = createComment("subredditname", "post title", "post text 10 5/7 miles");
+          ch.preprocessComment(comment)['body'].should.equal("post text 10.71 miles");
+        });
+        it('should convert mixed values into decimals', () => {
+          const comment = createComment("subredditname", "post title", "post text 1,707 05/09 miles more text");
+          ch.preprocessComment(comment)['body'].should.equal("post text 1,707.56 miles more text");
+        });
+        it('should convert mixed values into decimals', () => {
+          const comment = createComment("subredditname", "post title", "post text 98 7654/3,210 inches");
+          ch.preprocessComment(comment)['body'].should.equal("post text 100.38 inches");
+        });
+    });
+    context('comment contains fraction', () => {
+        it('should convert fractions into decimals', () => {
+          const comment = createComment("subredditname", "post title", "post text 9/10 miles");
+          ch.preprocessComment(comment)['body'].should.equal("post text 0.90 miles");
+        });
+        it('should convert fractions into decimals', () => {
+          const comment = createComment("subredditname", "post title", "post text 177/100 miles more text");
+          ch.preprocessComment(comment)['body'].should.equal("post text 1.77 miles more text");
+        });
+        it('should convert fractions into decimals', () => {
+          const comment = createComment("subredditname", "post title", "post text 987,654/3210 inches");
+          ch.preprocessComment(comment)['body'].should.equal("post text 307.68 inches");
+        });
+    });
+  });
+
   describe('#findPotentialConversions()', () => {
     context('lbs', () => {
       it('should find conversions', () => {

--- a/test/conversion_helper-test.js
+++ b/test/conversion_helper-test.js
@@ -44,16 +44,20 @@ describe('conversion_helper', () => {
   describe('#preprocessComment()', () => {
     context('comment contains mixed', () => {
         it('should convert mixed values into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 10 5/7 miles");
-          ch.preprocessComment(comment)['body'].should.equal("post text 10.71 miles");
+          const comment = createComment("subredditname", "post title", "post text 10 5/7-miles");
+          ch.preprocessComment(comment)['body'].should.equal("post text 10.71-miles");
         });
         it('should convert mixed values into decimals', () => {
           const comment = createComment("subredditname", "post title", "post text 1,707 05/09 miles more text");
-          ch.preprocessComment(comment)['body'].should.equal("post text 1,707.56 miles more text");
+          ch.preprocessComment(comment)['body'].should.equal("post text 1707.56 miles more text");
         });
         it('should convert mixed values into decimals', () => {
           const comment = createComment("subredditname", "post title", "post text 98 7654/3,210 inches");
           ch.preprocessComment(comment)['body'].should.equal("post text 100.38 inches");
+        });
+        it('should convert mixed values into decimals', () => {
+          const comment = createComment("subredditname", "post title", "post text 5+18/09 inches");
+          ch.preprocessComment(comment)['body'].should.equal("post text 7.00 inches");
         });
     });
     context('comment contains fraction', () => {

--- a/test/converter-test.js
+++ b/test/converter-test.js
@@ -166,11 +166,13 @@ describe('Converter', () => {
           [
             "1 troy ounces",
             "1.25 oz t",
+            "5/6 oz t",
             "5 ozt"
           ],
           {
             "1 troy ounces" : "31 g",
             "1.25 troy ounces" : "38.88 g",
+            "0.83 troy ounces" : "25.82 g",
             "5 troy ounces" : "160 g"
           }
         );
@@ -185,6 +187,19 @@ describe('Converter', () => {
           ],
           {
             "1.1 inches" : "2.8 cm"
+          }
+        );
+      });
+    });
+
+    context('inches', () => {
+      it('should convert', () => {
+        testConvert(
+          [
+            "1 2/3 inch"
+          ],
+          {
+            "1.67 inches" : "4.24 cm"
           }
         );
       });

--- a/test/converter-test.js
+++ b/test/converter-test.js
@@ -183,23 +183,12 @@ describe('Converter', () => {
       it('should convert', () => {
         testConvert(
           [
-            "1.1-inch"
+            "1.1-inch",
+            "1,001 2/3 inch"
           ],
           {
-            "1.1 inches" : "2.8 cm"
-          }
-        );
-      });
-    });
-
-    context('inches', () => {
-      it('should convert', () => {
-        testConvert(
-          [
-            "1 2/3 inch"
-          ],
-          {
-            "1.67 inches" : "4.24 cm"
+            "1.1 inches" : "2.8 cm",
+            "1,001.67 inches" : "25.44 metres"
           }
         );
       });
@@ -210,11 +199,13 @@ describe('Converter', () => {
         testConvert(
           [
             "2-furlongs",
-            "13-furlongs"
+            "13-furlongs",
+            "13/26 furlongs"
           ],
           {
             "2 furlongs": "400 metres",
-            "13 furlongs" : "2.6 km"
+            "13 furlongs" : "2.6 km",
+            "0.50 furlongs": "100.58 metres"
           }
         );
       });


### PR DESCRIPTION
Adding support for fractions in comments to handle queries like `1 5/6 inches`, `3/4 oz` etc.

Adds function `preprocessComment` to replace fractions in preprocessing. `fractionProcessor` works by first removing all occurrences of mixed values, then fractions, in that order of priority.

Allows mixed values to seperated by space or `+` symbol, and ends with space, or `-`

Fixes [#150962141](https://www.pivotaltracker.com/story/show/150962141)