### PR TITLE
Keyword triggers for fl oz instead of oz conversions

### DIFF
--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -78,6 +78,7 @@ const metricDistanceUnits = [/km/, /light-?years?/,
 const metricWeightUnits = [/kgs?/, /grams?/, /kilograms?/];
 const metricVolumeUnits = [/(?:milli|centi|deca|kilo)?lit(?:er|re)s?/, /(?:deca|kilo)?m(?:eters?)?(?:\^3| cubed?)/];
 const metricForceUnits = [/newtons?/, /dynes?/];
+const liquidKeywords = ['liquid', 'water', 'tea', 'beer', 'soda', 'cider', 'juice', 'coffee', 'liquor', 'milk', 'bottle', 'spirits', 'rum', 'vodka', 'tequila', 'wine', 'oil'];
 
 const ukSubreddits = ["britain", "british", "england", "english", "scotland", "scottish", "wales", "welsh", "ireland", "irish", "london", "uk"];
 
@@ -322,7 +323,27 @@ const unitLookupList = [
     "isWeaklyInvalidInput" : isHyperbole,
     "conversionFunction" : (i) => volumeMap(i * 0.0295735295625),
     "ignoredUnits" : metricVolumeUnits,
-    "ignoredKeywords" : ukSubreddits
+    "ignoredKeywords" : ukSubreddits,
+    "preprocess" : (comment) => {
+      const input = comment['body'];
+      const ozRegex = new RegExp(( rh.startRegex 
+          + rh.numberRegex
+          + "[- ]?"
+          + rh.regexJoinToString([/oz/, /ounces?/])
+        ),'gi');
+      const ozAndLiquidRegex = new RegExp(( ozRegex.source
+          + ".+?\\b"
+          + rh.regexJoinToString(liquidKeywords)
+        ),'i');
+
+      if (!ozAndLiquidRegex.test(input)) {
+        return input;
+      }
+
+      return input.replace(ozRegex, (oz, offset, string) => {
+        return " " + oz + " fl. oz";
+      });
+    }
   },
   {
     "imperialUnits" : [/oz/, /ounces?/],

--- a/test/converter-test.js
+++ b/test/converter-test.js
@@ -58,11 +58,13 @@ describe('Converter', () => {
         testConvert(
           [
             "10 fl oz",
-            "1001 oz. liquid"
+            "1001 oz. liquid",
+            "20 oz of water"
           ],
           {
             "10 fl. oz." : "300 mL",
-            "1,001 fl. oz." : "30 L"
+            "1,001 fl. oz." : "30 L",
+            "20 fl. oz." : "600 mL",
           }
         );
       });


### PR DESCRIPTION
Added a preprocess function to the "fl. oz" converter. Will check to see if it sees oz/ounces and a liquid keyword within the same line. If so, it will convert it to "fl. oz".

> input: 1 oz of water
> output: 1 fl. oz. ≈ 30 mL

> input: 8 oz steak 1.5 cups of water
> output8 oz ≈ 230 g  \n1.5 cups (US) ≈ 360.0 mL