### PR TITLE
Add eslint with airbnb base style guide [#45]

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "extends": "airbnb-base",
+    "env": {
+        "mocha": true,
+        "node": true
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ before_script:
   - mv ./sample-environment.yaml ./private/environment.yaml
 node_js:
   - "node"
+install:
+  - npm install
+script:
+  # - npm run-script lint
+  - npm test

--- a/package.json
+++ b/package.json
@@ -13,15 +13,19 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
+    "eslint": "^4.8.0",
+    "eslint-config-airbnb-base": "^12.0.2",
+    "eslint-plugin-import": "^2.7.0",
     "mocha": "^3.4.2",
-    "proxyquire": "^1.8.0"    
+    "proxyquire": "^1.8.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "eslint **/*.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/cannawen/metric_units_reddit_bot.git"
   },
-  "license" : "GPL-3.0"
+  "license": "GPL-3.0"
 }


### PR DESCRIPTION
This PR adds eslint as a dependency and modifies .travis.yml to run the linter before testing (currently its commented out, it should be uncommented in the future). Eslint is configured to follow airbnb's ecmascript [Style Guide](https://github.com/airbnb/javascript))

This also enables us to run the linter locally by running `npm run-script lint` or using `eslint` directly.

closes #45, gives way to #60 