### PR TITLE
Issue 64: Generate TOC for markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Introduction](#introduction)
+- [Etiquette](#etiquette)
+- [Make an issue](#make-an-issue)
+- [Contribute Code](#contribute-code)
+  - [New to Github](#new-to-github)
+  - [Find something to work on](#find-something-to-work-on)
+  - [Work on an issue](#work-on-an-issue)
+  - [Make a PR](#make-a-pr)
+    - [Required](#required)
+    - [Optional](#optional)
+  - [Add yourself to the contributors list](#add-yourself-to-the-contributors-list)
+- [Collaborators](#collaborators)
+  - [Help, I've been added as a collaborator! What do??](#help-ive-been-added-as-a-collaborator-what-do)
+  - [How do I become a collaborator?](#how-do-i-become-a-collaborator)
+- [The lifecycle of an issue](#the-lifecycle-of-an-issue)
+- [The lifecycle of a PR](#the-lifecycle-of-a-pr)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Introduction
 
 Thank you for your interest in contributing to metric_units reddit bot! This document is a guideline to help our community run smoothly.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Vision](#vision)
+- [How does the code work?](#how-does-the-code-work)
+- [Running the code](#running-the-code)
+- [Running the tests](#running-the-tests)
+- [Questions or Comments?](#questions-or-comments)
+- [Contribute](#contribute)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ![Build status](https://travis-ci.org/cannawen/metric_units_reddit_bot.svg?branch=master)
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "compile-pages.js",
   "dependencies": {
     "deasync": "^0.1.10",
+    "doctoc": "^1.3.0",
     "js-yaml": "^3.9.1",
     "request": "^2.81.0"
   },


### PR DESCRIPTION
Relevant to this issue: https://github.com/cannawen/metric_units_reddit_bot/issues/64
Generated a table of contents for the two markdown files in this project. 

Todo:
- [x] - Tests pass
- [ ] - Update documentation on how to use the doctoc tool whenever markdown files are changed