### PR TITLE
Parse number abbreviations [#46]

### DIFF
--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -580,7 +580,36 @@ function preprocessComment(comment) {
     return input;
   }
 
+  function abbreviationProcessor(comment) {
+    const abbreviations = {
+      k: 1000,
+      thousand: 1000,
+      m: 1000000,
+      mill: 1000000,
+    };
+
+    const abbreviationsRegex = Object.keys(abbreviations).map(
+      abbrev => new RegExp('\\s?' + abbrev + '\\b')
+    );
+    const match = new RegExp(rh.numberRegex + rh.regexJoinToString(abbreviationsRegex), 'gi');
+
+    comment = comment.replace(match, function(value) {
+      const text = /[a-z]+/gi;
+      const abbreviation = value.match(text)[0];
+
+      if (abbreviations[abbreviation]) {
+        value = value.replace(text, '');
+        value = parseFloat(value) * abbreviations[abbreviation];
+      }
+
+      return value;
+    })
+
+    return comment;
+  }
+
   comment['body'] = fractionProcessor(comment['body']);
+  comment['body'] = abbreviationProcessor(comment['body']);
   return comment;
 }
 

--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -556,62 +556,7 @@ function shouldConvertComment(comment, regexArray = globalIgnore, shouldBeUnique
   Output: Comment with body processed to fix user formatting
     "1.75 miles"
 */
-function preprocessComment(comment) {
-  function fractionProcessor(input) {
-    const frac = new RegExp(rh.fractionRegex, 'gi');
-    
-    const mixed = new RegExp(rh.numberRegex
-                    + /(?:[\s+-]+)/.source
-                    + rh.fractionRegex, 'gi');
 
-    input = input.replace(mixed, function(p1, p2, p3, p4, p5) {
-        p2 = p2.replace(/,+/g, '');
-        p3 = p3.replace(/,+/g, '');
-        p4 = p4.replace(/,+/g, '');
-        return (parseInt(p2)+parseInt(p3)/parseInt(p4)).toFixed(2) + p5;
-    });
-
-    input = input.replace(frac, function(p1, p2, p3, p4) {
-        p2 = p2.replace(/,+/g, '');
-        p3 = p3.replace(/,+/g, '');
-        return (p2/p3).toFixed(2) + p4;
-    });
-
-    return input;
-  }
-
-  function abbreviationProcessor(comment) {
-    const abbreviations = {
-      k: 1000,
-      thousand: 1000,
-      m: 1000000,
-      mill: 1000000,
-    };
-
-    const abbreviationsRegex = Object.keys(abbreviations).map(
-      abbrev => new RegExp('\\s?' + abbrev + '\\b')
-    );
-    const match = new RegExp(rh.numberRegex + rh.regexJoinToString(abbreviationsRegex), 'gi');
-
-    comment = comment.replace(match, function(value) {
-      const text = /[a-z]+/gi;
-      const abbreviation = value.match(text)[0];
-
-      if (abbreviations[abbreviation]) {
-        value = value.replace(text, '');
-        value = parseFloat(value) * abbreviations[abbreviation];
-      }
-
-      return value;
-    })
-
-    return comment;
-  }
-
-  comment['body'] = fractionProcessor(comment['body']);
-  comment['body'] = abbreviationProcessor(comment['body']);
-  return comment;
-}
 
 /*
   Input: String
@@ -978,7 +923,6 @@ function formatConversion(conversions) {
 module.exports = {
   globalIgnore,
   "shouldConvertComment" : shouldConvertComment,
-  "preprocessComment": preprocessComment,
   "findPotentialConversions" : findPotentialConversions,
   "filterConversions" : filterConversions,
   "calculateMetric" : calculateMetric,

--- a/src/converter.js
+++ b/src/converter.js
@@ -1,13 +1,14 @@
 const analytics = require('./analytics');
 const rh = require('./regex_helper');
 const ch = require('./conversion_helper');
+const pp = require('./preprocess');
 
 function conversions(comment) {
   if (!ch.shouldConvertComment(comment)) {
     return {};
   }
 
-  const preprocessedcomment = ch.preprocessComment(comment);
+  const preprocessedcomment = pp.preprocessComment(comment);
   const potentialConversions = ch.findPotentialConversions(preprocessedcomment);
   const filteredConversions = ch.filterConversions(potentialConversions);
   const metricConversions = ch.calculateMetric(filteredConversions);

--- a/src/preprocess.js
+++ b/src/preprocess.js
@@ -1,0 +1,71 @@
+const rh = require('./regex_helper');
+
+const abbreviations = [
+  { regexArray: [/k/, /thousand/], value: 1000 },
+  { regexArray: [/m/, /mill(?:ion)?/], value: 1000000 },
+  { regexArray: [/b/, /billion/], value: 1000000000 },
+];
+
+function fractionProcessor(input) {
+  const frac = new RegExp(rh.fractionRegex, 'gi');
+  const mixed = new RegExp(rh.numberRegex + /(?:[\s+-]+)/.source + rh.fractionRegex, 'gi');
+
+  input = input.replace(mixed, (p1, p2, p3, p4, p5) => {
+    p2 = p2.replace(/,+/g, '');
+    p3 = p3.replace(/,+/g, '');
+    p4 = p4.replace(/,+/g, '');
+    return (parseInt(p2, 10) + (parseInt(p3, 10) / parseInt(p4, 10))).toFixed(2) + p5;
+  });
+
+  input = input.replace(frac, (p1, p2, p3, p4) => {
+    p2 = p2.replace(/,+/g, '');
+    p3 = p3.replace(/,+/g, '');
+    return (p2 / p3).toFixed(2) + p4;
+  });
+
+  return input;
+}
+
+function abbreviationProcessor(commentBody) {
+  function replaceAbbreviation(text, abbrevRegex, value) {
+    const nonNumber = /[a-z]+/gi;
+    const abbrev = text.match(nonNumber)[0].toLowerCase();
+
+    if (abbrev.match(abbrevRegex)) {
+      const number = text.replace(nonNumber, '');
+      text = parseFloat(number) * value;
+    }
+    return text;
+  }
+
+  const newCommentBody = abbreviations.reduce((newCommentBody, abbreviation) => {
+    const abbrevRegex = rh.regexJoinToString(abbreviation.regexArray);
+    const regex = new RegExp(rh.numberRegex + '\\s?' + abbrevRegex + '\\b', 'gi');
+    const { value } = abbreviation;
+
+    return newCommentBody.replace(regex, (match) => {
+      return replaceAbbreviation(match, abbrevRegex, value);
+    });
+  }, commentBody);
+
+  return newCommentBody;
+}
+
+// Whenever a new preprocessing function is implemented,
+// it should be added here.
+const preprocessFunctions = [
+  fractionProcessor,
+  abbreviationProcessor,
+];
+
+function preprocessComment(comment) {
+  comment.body = preprocessFunctions.reduce((processedBody, preprocessFunction) => {
+    return preprocessFunction(processedBody);
+  }, comment.body);
+
+  return comment;
+}
+
+module.exports = {
+  preprocessComment,
+};

--- a/test/conversion_helper-test.js
+++ b/test/conversion_helper-test.js
@@ -74,6 +74,27 @@ describe('conversion_helper', () => {
           ch.preprocessComment(comment)['body'].should.equal("post text 307.68 inches");
         });
     });
+    context('comment contains multiplier', () => {
+      it('should convert multiplier into value', () => {
+        const comment = createComment("test", "post title", "Something like 40k miles");
+        ch.preprocessComment(comment)['body'].should.equal("Something like 40000 miles");
+      });
+      it('should convert multipliers if there is a space in between', () => {
+        const comment = createComment("test", "post title", "Something like 40 k miles");
+        ch.preprocessComment(comment)['body'].should.equal("Something like 40000 miles");
+      });
+      it('should convert numbers with decimals', () => {
+        const comment = createComment("test", "post title", "I won 3.2mill at the lottery");
+        ch.preprocessComment(comment)['body'].should.equal("I won 3200000 at the lottery");
+      });
+      it('should not convert multipliers that are a part of a unit', () => {
+        const kmComment = createComment("test", "post title", "The road is 30km long");
+        const mphComment = createComment("test", "post title", "My car can do 100mph");
+
+        ch.preprocessComment(kmComment)['body'].should.equal("The road is 30km long");
+        ch.preprocessComment(mphComment)['body'].should.equal("My car can do 100mph");
+      });
+    });
   });
 
   describe('#findPotentialConversions()', () => {

--- a/test/conversion_helper-test.js
+++ b/test/conversion_helper-test.js
@@ -1,7 +1,6 @@
 const should = require('chai').should();
 
 const ch = require('../src/conversion_helper');
-const pp = require('../src/preprocess');
 
 describe('conversion_helper', () => {
   describe('#shouldConvertComment()', () => {
@@ -74,7 +73,7 @@ describe('conversion_helper', () => {
             [1, 2, 3, 4, 5, 6, 7],
             " lb"
           );
-        }); 
+        });
       });
 
       context('and oz', () => {
@@ -88,7 +87,7 @@ describe('conversion_helper', () => {
             ["2.00", "2.50"],
             " lb"
           );
-        }); 
+        });
       });
     });
 
@@ -119,7 +118,7 @@ describe('conversion_helper', () => {
             [1, 2],
             " feet"
           );
-        }); 
+        });
       });
 
       context('and inches', () => {
@@ -191,7 +190,7 @@ describe('conversion_helper', () => {
             [1, 2, 3, 4],
             " inches"
           );
-        }); 
+        });
       });
     });
 
@@ -298,7 +297,7 @@ describe('conversion_helper', () => {
             [1, 2, 3, 4, 5, 6, 7, 8, 9],
             "°F"
           );
-        }); 
+        });
       });
     });
 
@@ -536,14 +535,14 @@ describe('conversion_helper', () => {
     });
 
     context('Mix of invalid, weak, and strong conversions', () => {
-      it('should allow weak and strong conversions', () => {        
+      it('should allow weak and strong conversions', () => {
         const potentialConversions = [
           createImperialMap(3, " lb"),
           createImperialMap(-10, " lb"),
           createImperialMap(10000, " lb"),
           createImperialMap(2, " feet"),
         ];
-        
+
         const expectedConversions = [
           createImperialMap(3, " lb"),
           createImperialMap(10000, " lb"),
@@ -559,7 +558,7 @@ describe('conversion_helper', () => {
         memo.push(createImperialMap(value, unit));
         return memo;
       }, []);
-      
+
       const expectedConversions = expectedValues.reduce((memo, value) => {
         memo.push(createImperialMap(value, unit));
         return memo;
@@ -576,7 +575,7 @@ describe('conversion_helper', () => {
           verifyConversion(1, " lb", 453.592, " g");
         });
       });
-      
+
       context('under 1,000 kg', () => {
         it('should convert to kg', () => {
           verifyConversion(3, " lb", 1.3607759999999998, " kg");
@@ -778,14 +777,14 @@ describe('conversion_helper', () => {
           it('should round to 3%', () => {
             verifyRounding(20, 96.888, 97);
             verifyRounding(20, -98.88, -100);
-          });        
+          });
         });
 
         context('greater than 100', () => {
           it('should round to 5%', () => {
             verifyRounding(200, 96.888, 100);
             verifyRounding(200, -94.88, -95);
-          });        
+          });
         });
       });
     });

--- a/test/conversion_helper-test.js
+++ b/test/conversion_helper-test.js
@@ -1,6 +1,7 @@
 const should = require('chai').should();
 
 const ch = require('../src/conversion_helper');
+const pp = require('../src/preprocess');
 
 describe('conversion_helper', () => {
   describe('#shouldConvertComment()', () => {
@@ -40,63 +41,6 @@ describe('conversion_helper', () => {
       });
     });
   });
-
-  describe('#preprocessComment()', () => {
-    context('comment contains mixed', () => {
-        it('should convert mixed values into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 10 5/7-miles");
-          ch.preprocessComment(comment)['body'].should.equal("post text 10.71-miles");
-        });
-        it('should convert mixed values into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 1,707 05/09 miles more text");
-          ch.preprocessComment(comment)['body'].should.equal("post text 1707.56 miles more text");
-        });
-        it('should convert mixed values into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 98 7654/3,210 inches");
-          ch.preprocessComment(comment)['body'].should.equal("post text 100.38 inches");
-        });
-        it('should convert mixed values into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 5+18/09 inches");
-          ch.preprocessComment(comment)['body'].should.equal("post text 7.00 inches");
-        });
-    });
-    context('comment contains fraction', () => {
-        it('should convert fractions into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 9/10-miles");
-          ch.preprocessComment(comment)['body'].should.equal("post text 0.90-miles");
-        });
-        it('should convert fractions into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 177/100 miles more text");
-          ch.preprocessComment(comment)['body'].should.equal("post text 1.77 miles more text");
-        });
-        it('should convert fractions into decimals', () => {
-          const comment = createComment("subredditname", "post title", "post text 987,654/3210 inches");
-          ch.preprocessComment(comment)['body'].should.equal("post text 307.68 inches");
-        });
-    });
-    context('comment contains multiplier', () => {
-      it('should convert multiplier into value', () => {
-        const comment = createComment("test", "post title", "Something like 40k miles");
-        ch.preprocessComment(comment)['body'].should.equal("Something like 40000 miles");
-      });
-      it('should convert multipliers if there is a space in between', () => {
-        const comment = createComment("test", "post title", "Something like 40 k miles");
-        ch.preprocessComment(comment)['body'].should.equal("Something like 40000 miles");
-      });
-      it('should convert numbers with decimals', () => {
-        const comment = createComment("test", "post title", "I won 3.2mill at the lottery");
-        ch.preprocessComment(comment)['body'].should.equal("I won 3200000 at the lottery");
-      });
-      it('should not convert multipliers that are a part of a unit', () => {
-        const kmComment = createComment("test", "post title", "The road is 30km long");
-        const mphComment = createComment("test", "post title", "My car can do 100mph");
-
-        ch.preprocessComment(kmComment)['body'].should.equal("The road is 30km long");
-        ch.preprocessComment(mphComment)['body'].should.equal("My car can do 100mph");
-      });
-    });
-  });
-
   describe('#findPotentialConversions()', () => {
     context('lbs', () => {
       it('should find conversions', () => {

--- a/test/preprocess-test.js
+++ b/test/preprocess-test.js
@@ -1,0 +1,74 @@
+const should = require('chai').should();
+const pp = require('../src/preprocess');
+
+function createComment(subreddit, title, body) {
+  return {
+    subreddit,
+    title,
+    body,
+  };
+}
+
+describe('#preprocessComment()', () => {
+  context('comment contains mixed', () => {
+    it('should convert mixed values into decimals', () => {
+      const comment = createComment('subredditname', 'post title', 'post text 10 5/7-miles');
+      pp.preprocessComment(comment).body.should.equal('post text 10.71-miles');
+    });
+    it('should convert mixed values into decimals', () => {
+      const comment = createComment('subredditname', 'post title', 'post text 1,707 05/09 miles more text');
+      pp.preprocessComment(comment).body.should.equal('post text 1707.56 miles more text');
+    });
+    it('should convert mixed values into decimals', () => {
+      const comment = createComment('subredditname', 'post title', 'post text 98 7654/3,210 inches');
+      pp.preprocessComment(comment).body.should.equal('post text 100.38 inches');
+    });
+    it('should convert mixed values into decimals', () => {
+      const comment = createComment('subredditname', 'post title', 'post text 5+18/09 inches');
+      pp.preprocessComment(comment).body.should.equal('post text 7.00 inches');
+    });
+  });
+  context('comment contains fraction', () => {
+    it('should convert fractions into decimals', () => {
+      const comment = createComment('subredditname', 'post title', 'post text 9/10-miles');
+      pp.preprocessComment(comment).body.should.equal('post text 0.90-miles');
+    });
+    it('should convert fractions into decimals', () => {
+      const comment = createComment('subredditname', 'post title', 'post text 177/100 miles more text');
+      pp.preprocessComment(comment).body.should.equal('post text 1.77 miles more text');
+    });
+    it('should convert fractions into decimals', () => {
+      const comment = createComment('subredditname', 'post title', 'post text 987,654/3210 inches');
+      pp.preprocessComment(comment).body.should.equal('post text 307.68 inches');
+    });
+  });
+  context('comment contains abbreviation', () => {
+    it('should convert abbreviation into value', () => {
+      const comment = createComment('test', 'post title', 'Something like 40k miles');
+      pp.preprocessComment(comment).body.should.equal('Something like 40000 miles');
+    });
+    it('should convert abbreviation case-insensitively', () => {
+      const comment = createComment('test', 'post title', 'Something like 40K miles');
+      pp.preprocessComment(comment).body.should.equal('Something like 40000 miles');
+    });
+    it('should convert abbreviations if there is a space in between', () => {
+      const comment = createComment('test', 'post title', 'Something like 40 k miles');
+      pp.preprocessComment(comment).body.should.equal('Something like 40000 miles');
+    });
+    it('should convert multiple abbreviations', () => {
+      const comment = createComment('test', 'post title', 'Somewhere between 30k and 40 thousand miles');
+      pp.preprocessComment(comment).body.should.equal('Somewhere between 30000 and 40000 miles');
+    });
+    it('should convert numbers with decimals', () => {
+      const comment = createComment('test', 'post title', 'I won 3.2mill at the lottery');
+      pp.preprocessComment(comment).body.should.equal('I won 3200000 at the lottery');
+    });
+    it('should not convert abbreviations that are a part of a unit', () => {
+      const kmComment = createComment('test', 'post title', 'The road is 30km long');
+      const mphComment = createComment('test', 'post title', 'My car can do 100mph');
+
+      pp.preprocessComment(kmComment).body.should.equal('The road is 30km long');
+      pp.preprocessComment(mphComment).body.should.equal('My car can do 100mph');
+    });
+  });
+});


### PR DESCRIPTION
closes #46 

This adds a comment preprocessor that expands number abbreviations to the full form (eg `4.5k -> 4500`). Supporting more abbreviations should be easy now, just add the `abbreviation: value` pair into the abbreviations object. 