### PR TITLE
Adds conversion comment refresh requests via Private Messages

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -15,6 +15,10 @@ function trackConversion(data) {
   track("conversion", data);
 }
 
+function trackEdit(data) {
+  track("edit", data);
+}
+
 function trackUnsubscribe(data) {
   track("unsubscribe", data);
 }
@@ -39,6 +43,7 @@ function track(category, data) {
 module.exports = {
   "trackPersonality" : trackPersonality,
   "trackConversion" : trackConversion,
+  "trackEdit" : trackEdit,
   "trackUnsubscribe" : trackUnsubscribe,
   "trackError" : trackError
 }

--- a/src/bot.js
+++ b/src/bot.js
@@ -138,7 +138,9 @@ function replyToMessages() {
       const commentId = message['subject'].match(/refresh (\w+)/i)[1];
       const comment = network.getComment('t1_' + commentId);
 
-      if (! comment) return;
+      if (! comment) {
+        return;
+      }
 
       const commentReplies = network.getCommentReplies(comment['link_id'], commentId);
 
@@ -146,16 +148,22 @@ function replyToMessages() {
         return reply['data']['author'].toLowerCase() == environment['reddit-username'].toLowerCase();
       });
 
-      if (! botReply) return;
+      if (! botReply) {
+        return;
+      }
 
       const conversions = converter.conversions(comment);
       const reply = replier.formatReply(comment, conversions);
 
-      if (Object.keys(conversions).length === 0) return;
+      if (Object.keys(conversions).length === 0) {
+        return;
+      }
 
       network.editComment('t1_' + botReply['data']['id'], reply);
 
-      if (! comment['link_id']) comment['link_id'] = 't3_value';
+      if (! comment['link_id']) {
+        comment['link_id'] = 't3_value';
+      }
 
       analytics.trackEdit([message['timestamp'], 'https://reddit.com/comments/' + comment['link_id'].replace(/t3_/g, '') + '//' + commentId, comment['body'], conversions]);
     });

--- a/src/bot.js
+++ b/src/bot.js
@@ -15,7 +15,7 @@ const personality = require('./personality');
 const environment = helper.environment();
 let replyMetadata = {};
 let excludedSubreddits = [];
-try { 
+try {
   excludedSubreddits = yaml
     .safeLoad(fs.readFileSync('./private/excluded_subreddits.yaml', 'utf8'))
     .map(subreddit => subreddit.toLowerCase());
@@ -63,7 +63,7 @@ function replyToMessages() {
         }
       });
   }
-  
+
   function messageIsShort(message) {
     return message['body'].length < 30;
   }
@@ -71,7 +71,7 @@ function replyToMessages() {
   const now = helper.now();
 
   network.refreshToken();
-  
+
   const messages = network.getUnreadMessages();
   network.markAllMessagesAsRead();
   if (!messages) {
@@ -85,7 +85,7 @@ function replyToMessages() {
       if (reply === undefined) {
         return;
       }
-      
+
       if (message['subreddit'].match(/^totallynotrobots$/i)) {
         const humanReply = personality.humanReply(message);
         if (humanReply) {
@@ -93,7 +93,7 @@ function replyToMessages() {
           network.postComment(message['id'], humanReply);
         }
         return;
-      } 
+      }
 
       const postTitle = message['postTitle'];
 
@@ -104,21 +104,21 @@ function replyToMessages() {
 
       if (replyMetadata[postTitle] === undefined) {
         shouldReply = true;
-        replyMetadata[postTitle] = { 
-          'timestamp' : now, 
+        replyMetadata[postTitle] = {
+          'timestamp' : now,
           'personalityReplyChance' : 0.5
         };
 
       } else if (helper.random() < replyMetadata[postTitle]['personalityReplyChance']) {
         shouldReply = true;
-        Object.assign(replyMetadata[postTitle], { 
-          'timestamp' : now, 
+        Object.assign(replyMetadata[postTitle], {
+          'timestamp' : now,
           'personalityReplyChance': replyMetadata[postTitle]['personalityReplyChance'] / 2
         });
       }
 
       analytics.trackPersonality([message['timestamp'], message['link'], message['body'], reply, shouldReply]);
-      
+
       if (shouldReply) {
         network.postComment(message['id'], reply);
       }
@@ -130,6 +130,40 @@ function replyToMessages() {
       analytics.trackUnsubscribe([message['timestamp'], message['username']]);
       network.postComment(message['id'], replier.stopMessage);
       network.blockAuthorOfMessageWithId(message['id']);
+    });
+
+  filterPrivateMessages(messages)
+    .filter(message => message['subject'].match(/refresh (\w+)/i))
+    .forEach(message => {
+      const commentId = message['subject'].match(/refresh (\w+)/i)[1];
+      let commentData = network.getComment('t1_' + commentId);
+
+      if (commentData.length === 0) return;
+
+      commentData = commentData[0]['data'];
+
+      const comment = {
+        'body': commentData['body'],
+        'id': commentData['name'],
+        'postTitle': 'This is a dummy value.',
+        'timestamp' : commentData['created_utc'],
+        'subreddit' : commentData['subreddit'],
+        'username' : commentData['author'],
+        'link_id' : commentData['link_id']
+      }
+
+      const commentReplies = network.getCommentReplies(comment['link_id'], commentId);
+
+      const botReplyId = commentReplies['json']['data']['things'].find(reply => {
+        return reply['data']['author'].toLowerCase() == environment['reddit-username'].toLowerCase();
+      })['data']['id'];
+
+      const conversions = converter.conversions(comment);
+      const reply = replier.formatReply(comment, conversions);
+
+      if (Object.keys(conversions).length === 0) return;
+
+      network.editComment('t1_' + botReplyId, reply);
     });
 
   //cleanup old replyMetadata
@@ -177,7 +211,7 @@ function postConversions() {
     //If we have not seen this post within 24 hours
     if (replyMetadata[postTitle] === undefined) {
       replyMetadata[postTitle] = {
-          'timestamp' : helper.now(), 
+          'timestamp' : helper.now(),
           'personalityReplyChance' : 1,
           'conversions' : newConversions
       }
@@ -219,12 +253,12 @@ function postConversions() {
   function hasConversions(map) {
     return Object.keys(map['conversions']).length > 0;
   }
-  
+
   const comments = network.getRedditComments("all");
   if (!comments) {
     return;
   }
-  
+
   comments
     .filter(commentIsntFromABot)
     .filter(allowedToPostInSubreddit)
@@ -248,4 +282,5 @@ function postConversions() {
       analytics.trackConversion([comment['timestamp'], comment['link'], comment['body'], conversions]);
       network.postComment(comment['id'], reply);
     })
-};  
+
+};

--- a/src/bot.js
+++ b/src/bot.js
@@ -136,34 +136,24 @@ function replyToMessages() {
     .filter(message => message['subject'].match(/refresh (\w+)/i))
     .forEach(message => {
       const commentId = message['subject'].match(/refresh (\w+)/i)[1];
-      let commentData = network.getComment('t1_' + commentId);
+      const comment = network.getComment('t1_' + commentId);
 
-      if (commentData.length === 0) return;
-
-      commentData = commentData[0]['data'];
-
-      const comment = {
-        'body': commentData['body'],
-        'id': commentData['name'],
-        'postTitle': 'This is a dummy value.',
-        'timestamp' : commentData['created_utc'],
-        'subreddit' : commentData['subreddit'],
-        'username' : commentData['author'],
-        'link_id' : commentData['link_id']
-      }
+      if (! comment) return;
 
       const commentReplies = network.getCommentReplies(comment['link_id'], commentId);
 
-      const botReplyId = commentReplies['json']['data']['things'].find(reply => {
+      const botReply = commentReplies.find(reply => {
         return reply['data']['author'].toLowerCase() == environment['reddit-username'].toLowerCase();
-      })['data']['id'];
+      });
+
+      if (! botReply) return;
 
       const conversions = converter.conversions(comment);
       const reply = replier.formatReply(comment, conversions);
 
       if (Object.keys(conversions).length === 0) return;
 
-      network.editComment('t1_' + botReplyId, reply);
+      network.editComment('t1_' + botReply['data']['id'], reply);
     });
 
   //cleanup old replyMetadata

--- a/src/bot.js
+++ b/src/bot.js
@@ -154,6 +154,7 @@ function replyToMessages() {
       if (Object.keys(conversions).length === 0) return;
 
       network.editComment('t1_' + botReply['data']['id'], reply);
+      analytics.trackEdit([message['timestamp'], 'https://reddit.com/comments/' + comment['link_id'].replace(/t3_/g, '') + '//' + commentId, comment['body'], conversions]);
     });
 
   //cleanup old replyMetadata

--- a/src/bot.js
+++ b/src/bot.js
@@ -154,6 +154,9 @@ function replyToMessages() {
       if (Object.keys(conversions).length === 0) return;
 
       network.editComment('t1_' + botReply['data']['id'], reply);
+
+      if (! comment['link_id']) comment['link_id'] = 't3_value';
+
       analytics.trackEdit([message['timestamp'], 'https://reddit.com/comments/' + comment['link_id'].replace(/t3_/g, '') + '//' + commentId, comment['body'], conversions]);
     });
 

--- a/src/network.js
+++ b/src/network.js
@@ -11,7 +11,7 @@ var oauthTokenValidUntil = undefined;
 var lastProcessedCommentId = undefined;
 
 function get(url) {
-  let content;  
+  let content;
 
   if (url.startsWith('http')) {
     content = networkRequest({ url: url }, false);
@@ -41,7 +41,7 @@ function post(urlPath, form) {
 
 function networkRequest(options, oauthRequest) {
   function redditOauthHeader() {
-    const userAgent = 
+    const userAgent =
      "script:" + environment['reddit-username'] + ":" + environment['version']
       + " (by: /u/" + environment['reddit-username'] + ")";
 
@@ -129,7 +129,7 @@ function printBannedSubreddits() {
       .filter(match => match !== null)
       .map(match => match[1])
       .forEach(subreddit => helper.log("- " + subreddit));
-    
+
     const lastMessageId = messages[messages.length - 1]['data']['name'];
 
     messages = get("/message/inbox?limit=100&after=" + lastMessageId)
@@ -171,6 +171,18 @@ function postComment(parentId, markdownBody) {
   post('/api/comment', { 'parent' : parentId, 'text' : markdownBody });
 }
 
+function getComment(commentId) {
+  return get('https://www.reddit.com/api/info.json?id=' + commentId);
+}
+
+function editComment(commentId, markdownBody) {
+  post('/api/editusertext', { 'thing_id' : commentId, 'text' : markdownBody });
+}
+
+function getCommentReplies(linkId, commentId) {
+  return get('https://www.reddit.com/api/morechildren.json?api_type=json&link_id=' + linkId + '&children=' + commentId);
+}
+
 function getUnreadMessages() {
   return get("/message/unread?limit=100");
 }
@@ -186,7 +198,10 @@ function blockAuthorOfMessageWithId(id) {
 module.exports = {
   "refreshToken" : refreshToken,
   "getRedditComments" : getRedditComments,
+  "getComment" : getComment,
   "postComment" : postComment,
+  "editComment" : editComment,
+  "getCommentReplies" : getCommentReplies,
   "getUnreadMessages" : getUnreadMessages,
   "markAllMessagesAsRead" : markAllMessagesAsRead,
   "blockAuthorOfMessageWithId" : blockAuthorOfMessageWithId

--- a/src/network.js
+++ b/src/network.js
@@ -185,7 +185,7 @@ function getComment(commentId) {
     'author': data['author'],
     'id': data['name'],
     'link_id' : data['link_id'],
-    'postTitle': 'This is a dummy value.',
+    'postTitle': '', // api/info does not return a value for postTitle but this property is required by shouldConvertComment
     'subreddit': data['subreddit'],
     'timestamp' : data['created_utc']
   }

--- a/src/network.js
+++ b/src/network.js
@@ -174,7 +174,9 @@ function postComment(parentId, markdownBody) {
 function getComment(commentId) {
   const comment = get('https://www.reddit.com/api/info.json?id=' + commentId);
 
-  if (comment.length == 0) return;
+  if (comment.length == 0) {
+    return;
+  }
 
   const data = comment[0]['data'];
 
@@ -196,8 +198,10 @@ function editComment(commentId, markdownBody) {
 function getCommentReplies(linkId, commentId) {
   const replies = get('https://www.reddit.com/api/morechildren.json?api_type=json&link_id=' + linkId + '&children=' + commentId);
 
-  if (! replies.length === 0) return null;
-
+  if (! replies.length === 0) {
+    return null;
+  }
+  
   return replies['json']['data']['things'];
 }
 

--- a/src/network.js
+++ b/src/network.js
@@ -172,7 +172,21 @@ function postComment(parentId, markdownBody) {
 }
 
 function getComment(commentId) {
-  return get('https://www.reddit.com/api/info.json?id=' + commentId);
+  const comment = get('https://www.reddit.com/api/info.json?id=' + commentId);
+
+  if (comment.length == 0) return;
+
+  const data = comment[0]['data'];
+
+  return {
+    'body': data['body'],
+    'author': data['author'],
+    'id': data['name'],
+    'link_id' : data['link_id'],
+    'postTitle': 'This is a dummy value.',
+    'subreddit': data['subreddit'],
+    'timestamp' : data['created_utc']
+  }
 }
 
 function editComment(commentId, markdownBody) {
@@ -180,7 +194,11 @@ function editComment(commentId, markdownBody) {
 }
 
 function getCommentReplies(linkId, commentId) {
-  return get('https://www.reddit.com/api/morechildren.json?api_type=json&link_id=' + linkId + '&children=' + commentId);
+  const replies = get('https://www.reddit.com/api/morechildren.json?api_type=json&link_id=' + linkId + '&children=' + commentId);
+
+  if (! replies.length === 0) return null;
+
+  return replies['json']['data']['things'];
 }
 
 function getUnreadMessages() {

--- a/src/reply_maker.js
+++ b/src/reply_maker.js
@@ -7,6 +7,7 @@ function formatReply(comment, conversions) {
   let source = "source"
   let version = environment['version'];
   let subreddit = comment['subreddit'];
+  let commentId = comment['id'];
   let transform = (x) => x;
 
   if (comment['subreddit'].match(/^totallynotrobots$/i)) {
@@ -17,22 +18,31 @@ function formatReply(comment, conversions) {
     transform = (x) => x.toUpperCase();
   }
 
+  const items = [
+    {"value" : "metric units " + species },
+    {"type" : "link", "value" : "feedback", "href" : "https://redd.it/73edn2" },
+    {"type" : "link", "value" : "source", "href" : "https://github.com/cannawen/metric_units_reddit_bot" },
+    {"type" : "link", "value" : "hacktoberfest", "href" : "https://redd.it/73ef7e" },
+    {"type" : "link", "value" : "block", "href" : formatRedditComposeLink(environment['reddit-username'], 'block', stopMessage) },
+    {"type" : "link", "value" : "refresh conversion", "href" : formatRedditComposeLink(environment['reddit-username'], 'refresh ' + commentId, "Please click 'send' below and I will update my comment to convert any new or updated values in your comment.") },
+    {"value" : version }
+  ];
+
+  const footer = items.map(item => {
+    item.value = transform(item.value);
+    item.value = '^' + item.value.replace(/ /g, ' ^');
+    if (item.type == 'link') item.value = `[${item.value}](${item.href})`;
+    return item.value;
+  }).join(' ^| ');
+
   return Object.keys(conversions)
     .map(nonMetricValue => nonMetricValue + " ≈ " + conversions[nonMetricValue])
     .map(transform)
-    .join("  \n")
-    + "\n\n"
-    + transform("^metric ^units ^" + species)
-    + " ^|"
-    + " ^[" + transform("feedback") + "](https://www.reddit.com/r/metric_units/comments/73edn2/constructive_feedback_thread/)"
-    + " ^|"
-    + " ^[" + source + "](https://github.com/cannawen/metric_units_reddit_bot)"
-    + " ^|"
-    + " ^[" + transform("hacktoberfest") + "](https://www.reddit.com/r/metric_units/comments/73ef7e/contribute_to_metric_units/)"
-    + " ^|"
-    + " ^[" + transform("block") + "](https://www.reddit.com/message/compose?to=metric_units&subject=stop&message=If%20you%20would%20like%20to%20stop%20seeing%20this%20bot%27s%20comments%2C%20please%20send%20this%20private%20message%20with%20the%20subject%20%27stop%27.%20If%20you%20are%20a%20moderator%2C%20please%20go%20to%20https%3A%2F%2Fwww.reddit.com%2Fr%2F" + subreddit + "%2Fabout%2Fbanned%2F)"
-    + " ^|"
-    + " ^" + version;
+    .join("  \n") + '\n\n' + footer;
+}
+
+function formatRedditComposeLink(to, subject, message) {
+  return 'https://www.reddit.com/message/compose?to=' + to + '&subject=' + encodeURIComponent(subject) + '&message=' + encodeURIComponent(message);
 }
 
 module.exports = {

--- a/src/reply_maker.js
+++ b/src/reply_maker.js
@@ -31,7 +31,11 @@ function formatReply(comment, conversions) {
   const footer = items.map(item => {
     item.value = transform(item.value);
     item.value = '^' + item.value.replace(/ /g, ' ^');
-    if (item.type == 'link') item.value = `[${item.value}](${item.href})`;
+
+    if (item.type == 'link') {
+      item.value = `[${item.value}](${item.href})`;
+    }
+
     return item.value;
   }).join(' ^| ');
 

--- a/test/bot-test.js
+++ b/test/bot-test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const should = require('chai').should();
-const proxyquire =  require('proxyquire')
+const proxyquire =  require('proxyquire');
 
 describe('Bot', () => {
   let bot;
@@ -14,6 +14,14 @@ describe('Bot', () => {
   let getUnreadMessagesReturnValue;
   let getUnreadMessagesCalled;
   let markAllMessagesAsReadCalled;
+  let getCommentId;
+  let getCommentReturnValue;
+  let getCommentRepliesLinkId;
+  let getCommentRepliesCommentId;
+  let getCommentRepliesCalled;
+  let editCommentId;
+  let editCommentBody;
+  let editCommentCalled;
 
   //Helper
   let commentFunction;
@@ -45,11 +53,11 @@ describe('Bot', () => {
 
     //Network
     refreshTokenCount = 0;
-    networkStub.refreshToken = () => { 
+    networkStub.refreshToken = () => {
       refreshTokenCount = refreshTokenCount + 1;
     };
     getRedditCommentsParam = undefined;
-    networkStub.getRedditComments = (param) => { 
+    networkStub.getRedditComments = (param) => {
       getRedditCommentsParam = param;
       return getRedditCommentsReturnValue;
     };
@@ -69,13 +77,35 @@ describe('Bot', () => {
     networkStub.markAllMessagesAsRead = () => {
       markAllMessagesAsReadCalled = true;
     };
+    getCommentId = undefined;
+    networkStub.getComment = (id) => {
+      getCommentId = id;
+      return getCommentReturnValue;
+    };
+    getCommentRepliesLinkId = undefined;
+    getCommentRepliesCommentId = undefined;
+    getCommentRepliesCalled = false;
+    networkStub.getCommentReplies = (linkId, commentId) => {
+      getCommentRepliesLinkId = linkId;
+      getCommentRepliesCommentId = commentId;
+      getCommentRepliesCalled = true;
+      return getCommentRepliesReturnValue;
+    };
+    editCommentId = undefined;
+    editCommentBody = undefined;
+    editCommentCalled = false;
+    networkStub.editComment = (id, body) => {
+      editCommentId = id;
+      editCommentBody = body;
+      editCommentCalled = true;
+    };
 
     //Helper
     commentFunction = undefined;
     commentSeconds = undefined;
     privateMessageFunction = undefined;
     privateMessageSeconds = undefined;
-    helperStub.setIntervalSafely = (f, seconds) => { 
+    helperStub.setIntervalSafely = (f, seconds) => {
       if (commentFunction === undefined) {
         commentFunction = f;
         commentSeconds = seconds;
@@ -85,6 +115,10 @@ describe('Bot', () => {
       }
     };
     helperStub.random = () => randomNumber;
+
+    helperStub.environment = () => {
+      return { 'reddit-username' : 'metric_units' };
+    }
 
     //Converter
     conversionCommentParam = undefined;
@@ -113,7 +147,7 @@ describe('Bot', () => {
       return personalityRetunValue;
     };
 
-    bot = proxyquire('../src/bot', { 
+    bot = proxyquire('../src/bot', {
       './helper': helperStub,
       './network' : networkStub,
       './converter' : converterStub,
@@ -184,7 +218,7 @@ describe('Bot', () => {
           let botComment = createComment({'body': '79 miles I am a bot.'});
           let longComment = createComment({'body': '79 miles careful: the variable settings will be modified, though. jQuery doesnt return a new instance. The reason for this (and for the naming) is that .extend() was developed to extend object  doesnt return a new instance. The reason for this (and for the naming) is that .extend() was developed too'})
           let sarcasticComment = createComment({'body': '79 miles /s'});
-          
+
           getRedditCommentsReturnValue = [
             noNumberComment,
             botComment,
@@ -262,7 +296,7 @@ describe('Bot', () => {
               postCommentId = undefined;
               postCommentBody = undefined;
               privateMessageFunction();
-              
+
               should.equal(postCommentId, undefined);
               should.equal(postCommentBody, undefined);
             });
@@ -282,6 +316,65 @@ describe('Bot', () => {
             privateMessageFunction();
             postCommentId.should.equal('789');
             postCommentBody.should.equal('please block me');
+          });
+        });
+
+        context('direct message with valid refresh request', () => {
+          beforeEach(() => {
+            let directMessage = createNetworkComment(
+              't4',
+              { 'name' : '401', 'subject' : 'refresh do4agao' }
+            );
+            getUnreadMessagesReturnValue = [directMessage];
+            let comment = createNetworkComment(
+              't1',
+              { 'body': 'value 1', 'id': '101', 'link_id' : '301' }
+            );
+            getCommentReturnValue = [comment];
+            let userReply = createNetworkComment(
+              't1',
+              { 'body': 'value 1 is value 2', 'author': 'not_bot',
+                'id': '102', 'link_id' : '301' }
+            );
+            let botReply = createNetworkComment(
+              't1',
+              { 'body': 'value 1 is value 2', 'author': 'metric_units',
+                'id': '103', 'link_id' : '301' }
+            );
+            getCommentRepliesReturnValue = [
+              userReply,
+              botReply
+            ];
+          });
+
+          it('should edit comment with new conversion value', () => {
+            conversionReturnValue = {"1": "2"};
+            replyReturnValue = "value 1 is value 2";
+            privateMessageFunction();
+
+            editCommentId.should.equal('t1_103');
+            editCommentBody.should.equal('value 1 is value 2');
+          });
+
+          it('should not edit comment if no value to convert is found', () => {
+            conversionReturnValue = {};
+            privateMessageFunction();
+
+            editCommentCalled.should.equal(false);
+          });
+        });
+
+        context('direct message with invalid refresh request', () => {
+          it('should skip message if request for id that does not exist on reddit', () => {
+            let directMessage = createNetworkComment(
+              't4',
+              { 'name' : '789', 'subject' : 'refresh blah' }
+            );
+            getUnreadMessagesReturnValue = [directMessage];
+            getCommentReturnValue = null;
+            privateMessageFunction();
+
+            getCommentRepliesCalled.should.equal(false);
           });
         });
       });
@@ -329,4 +422,3 @@ function createNetworkComment(kind, map) {
             }, map)
   }
 }
-

--- a/test/bot-test.js
+++ b/test/bot-test.js
@@ -154,7 +154,8 @@ describe('Bot', () => {
       './reply_maker' : replyStub,
       './analytics' : { trackConversion: (x) => x,
                         trackPersonality: (x) => x,
-                        trackUnsubscribe: (x) => x },
+                        trackUnsubscribe: (x) => x,
+                        trackEdit: (x) => x },
       './personality' : personalityStub
     });
   });

--- a/test/reply_maker-test.js
+++ b/test/reply_maker-test.js
@@ -40,5 +40,17 @@ describe('reply_maker', () => {
         .should
         .include("^METRIC ^UNITS ^HUMAN")
     });
+
+    it('should include footer links', () => {
+      replier.formatReply({ 'subreddit': 'all', 'id' : '101' }, {"foo" : "bar"} )
+      .should
+      .include("[^feedback](https://redd.it/73edn2)")
+      .and
+      .include("[^source](https://github.com/cannawen/metric_units_reddit_bot)")
+      .and
+      .include("[^block](https://www.reddit.com/message/compose")
+      .and
+      .include("[^refresh ^conversion](https://www.reddit.com/message/compose")
+    });
   });
 });


### PR DESCRIPTION
This is my first attempt at implementing refresh requests via Private Messages sent to the bot. I am not very familiar with nodejs so I hit a stumbling block with writing tests, — any guidance on that would be greatly appreciated. Specifically, the function `privateMessageFunction` is [being called at the start of each Private Message test](https://github.com/cannawen/metric_units_reddit_bot/blob/master/test/bot-test.js#L282) but I can’t find what that function does — [where does `f` come from?](https://github.com/cannawen/metric_units_reddit_bot/blob/master/test/bot-test.js#L83)

There are quite a few erroneous tab/space characters in the `bot.js` and `network.js` files which my editor (Atom) automatically removed. I couldn't find a way to stop Atom removing them, so my commit is polluted with those changes. Sorry :-( 

Left to do before this is mergeable:

- [x] Add tests
- [x] Add analytics
- [x] Add the footer link for creating a PM

Some notes on my implementation:

- Requires 3 API requests to complete the refresh process.
- Refreshes when a PM containing "refresh {id}" as the subject is received.
- `postTitle` is a required value for the conversion process, however, the comment endpoint does not return the value so I have used `This is a dummy value.` to allow it to function instead of refactoring the comment conversion process as to keep my changes small.
- Does not reply to the user to confirm the refresh request has been received — I'm not sure if Private Messages are rate limited by reddit, can add this if there aren't concerns about hitting Private Message limits.
- If the ID provided does not return a value from the reddit API then the refresh request is skipped.
- If the comment no longer has anything to convert then no edit is made.

When a comment has been edited and no longer contains any values that need to be converted, we could either delete the bot reply or we could edit it. I did not implement deleting the reply because I think it might be fun if instead the bot reply is edited with personality, something referencing the fact that the bot was made to do work unnecessarily. This would be a fairly easy feature to implement and would be high impact so I think it would be good to leave it as something for a first timer to implement instead of implementing it as part of this change. 

Closes #67 