### PR TITLE
Fixes unnecessary explicit comment type reference

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -136,7 +136,7 @@ function replyToMessages() {
     .filter(message => message['subject'].match(/refresh (\w+)/i))
     .forEach(message => {
       const commentId = message['subject'].match(/refresh (\w+)/i)[1];
-      const comment = network.getComment('t1_' + commentId);
+      const comment = network.getComment(commentId);
 
       if (! comment) {
         return;


### PR DESCRIPTION
This fixes a bug (woops! sorry!) with the refresh functionality. The comment ID does not need to have `t1_` prepended. 