### PR TITLE
Fixes malformed comment ID 

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -196,8 +196,8 @@ function editComment(commentId, markdownBody) {
 }
 
 function getCommentReplies(linkId, commentId) {
-  const replies = get('https://www.reddit.com/api/morechildren.json?api_type=json&link_id=' + linkId + '&children=' + commentId);
-
+  const replies = get('https://www.reddit.com/api/morechildren.json?api_type=json&link_id=' + linkId + '&children=' + commentId.replace(/t1_/g, ''));
+  
   if (! replies.length === 0) {
     return null;
   }


### PR DESCRIPTION
When fixing the issue in #91 I didn't realise that it would impact this part of the code too. This fix means that conversion refreshes will work, as they currently do not. 

A re-release will be required after this fix is merged.