### PR TITLE
Bugfix: Fix postprocessInput and add tests

### DIFF
--- a/src/conversion_helper.js
+++ b/src/conversion_helper.js
@@ -243,12 +243,18 @@ const unitLookupList = [
         }
       });
     },
-    "postprocessInput" : (input) => {
-      if (input.toString().indexOf('.') == -1) {
-        return rh.addCommas(input) + " feet";
+    "postprocessInput" : (numbers) => {
+      if (numbers.every((input) => input.toString().indexOf('.') == -1)) {
+        return numbers.map(function(input, index) {
+          if(index == numbers.length-1) {
+            return rh.addCommas(input) + " feet"
+          } else {
+            return rh.addCommas(input);
+          }
+        });
       } else {
-        return rh.addCommas(Math.floor(input).toString()) + "'" 
-               + roundToDecimalPlaces(input%1 * 12, 0) + "\"";
+        return numbers.map((input) => rh.addCommas(Math.floor(input).toString()) + "'" 
+                + roundToDecimalPlaces(input%1 * 12, 0) + "\"");
       }
     },
   },
@@ -330,12 +336,18 @@ const unitLookupList = [
         }
       });
     },
-    "postprocessInput" : (input) => {
-      if (input.toString().indexOf('.') == -1) {
-        return rh.addCommas(input) + " lb";
+    "postprocessInput" : (numbers) => {
+      if (numbers.every((input) => input.toString().indexOf('.') == -1)) {
+        return numbers.map(function(input, index) {
+          if(index == numbers.length-1) {
+            return rh.addCommas(input) + " lb"
+          } else {
+            return rh.addCommas(input);
+          }
+        });
       } else {
-        return rh.addCommas(Math.floor(input).toString()) + " lb " 
-               + roundToDecimalPlaces(input%1 * 16, 0) + " oz";
+        return numbers.map((input) => rh.addCommas(Math.floor(input).toString()) + " lb " 
+               + roundToDecimalPlaces(input%1 * 16, 0) + " oz");
       }
     }
   },
@@ -953,13 +965,17 @@ function formatConversion(conversions) {
 
     const imperialUnit = conversion['imperial']['unit'];
     const imperialNumbers = conversion['imperial']['numbers'];
+    const imperialJoiner = conversion['imperial']['joiner'];
 
     const postprocessInput = unitLookupMap[imperialUnit]['postprocessInput'];
     if (postprocessInput) {
       conversion['imperial'] = {
-        'numbers':imperialNumbers.map(postprocessInput),
+        'numbers': postprocessInput(imperialNumbers),
         'unit': ""
       };
+      if(imperialJoiner) {
+        conversion['imperial']['joiner'] = imperialJoiner;
+      }
     } else {
       conversion['imperial']['numbers'] = imperialNumbers.map(rh.addCommas);
     }

--- a/test/conversion_helper-test.js
+++ b/test/conversion_helper-test.js
@@ -1008,7 +1008,7 @@ describe('conversion_helper', () => {
           }])[0];
 
           const expected = {
-            'imperial' : createMap(["5 feet", "8 feet"], ""),
+            'imperial' : createMap(["5", "8 feet"], ""),
             'metric' : createMap(["2", "3"], " metres"),
             'rounded' : createMap(["2", "3"], " metres"),
             'formatted' : createMap(["2", "3"], " metres")

--- a/test/converter-test.js
+++ b/test/converter-test.js
@@ -25,10 +25,12 @@ describe('Converter', () => {
       it('should convert', () => {
         testConvert(
           [
-            "1001 lb"
+            "1001 lb",
+            "1000 - 2000 lbs"
           ],
           {
-            "1,001 lb" : "450 kg"
+            "1,001 lb" : "450 kg",
+            "1,000 - 2,000 lb" : "450 - 900 kg"
           }
         );
       });
@@ -91,10 +93,14 @@ describe('Converter', () => {
             [
               "3 feet",
               "5 feet",
+              "5 to 10 feet",
+              "5.3 - 7 feet"
             ],
             {
               "3 feet" : "90 cm",
-              "5 feet" : "1.5 metres"
+              "5 feet" : "1.5 metres",
+              "5 to 10 feet": "1.5 to 3 metres",
+              "5\'4\" - 7\'0\"": "1.6 - 2.1 metres"
             }
           );
       });


### PR DESCRIPTION
## PR Checklist
<!-- Hello, thanks for opening a PR in our project!  

- [x] Check off an item by placing an x in the square brackets  -->
- [x] I have read the [Contributing Guidelines](https://github.com/cannawen/metric_units_reddit_bot/blob/master/CONTRIBUTING.md)
- [x] New functionality (or bug fix) is appropriately tested
- [x] PR includes `closes #{issue number}` if appropriate
<!--
- [ ] Add more items that you need to do before this is merge-able
- [ ] OPTIONAL: Add myself to [the contributors list](https://github.com/cannawen/metric_units_reddit_bot/blob/master/CONTRIBUTING.md#add-yourself-to-the-contributors-list)
-->

## Brief description of changes:
<!-- Optional: Discuss architecture changes or design decisions in detail -->
Fixes the way post processing of input works so it doesn't add name of unit to all elements of `numbers`, just the last one.
Fixes `formatConversion()` to retain joiner if it exists before.

See added tests for examples of conversions and their formats.
## Relevant link(s):
Closes #111 