### PR TITLE
Fix 404 personality.js link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The app starts in [bot.js](./src/bot.js), and it polls the Reddit servers in an 
 
 [converter.js](./src/converter.js) and [conversion_helper.js](./src/conversion_helper.js) are responsible for converting imperial units to metric units. [See documentation to add a conversion](./docs/ADD_CONVERSION.md)
 
-[personality.js](./src/personality.js) create sassy responses to certain trigger words
+[personality/index.js](./src/personality/index.js) create sassy responses to certain trigger words.
 
 
 # Running the code


### PR DESCRIPTION
## PR Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/cannawen/metric_units_reddit_bot/blob/master/.github/CONTRIBUTING.md)
- [x] New functionality (or bug fix) is appropriately tested
- [x] PR includes `closes #{issue number}` if appropriate
- [x] Is only changing documentation

## Brief description of changes:

Updates the link that was to `personality.js` to [src/personality/index.js](https://github.com/cannawen/metric_units_reddit_bot/blob/master/src/personality/index.js) since it looks like that source file has changed.

## Relevant link(s):

n/a

:grin: 